### PR TITLE
fix: Revert Docker configuration to amd64 for local dev

### DIFF
--- a/.github/workflows/ci-cd_prod.yml
+++ b/.github/workflows/ci-cd_prod.yml
@@ -39,7 +39,7 @@ jobs:
       # Build the Docker images
       - name: Build Docker image
         run: |
-          docker compose build --parallel
+          docker compose -f docker-compose.deploy.yaml build --parallel
           docker tag clio-airflow-webserver:latest lhernandez0/clio-airflow-common:latest
           docker tag clio-clio_webserver:latest lhernandez0/clio-webserver:latest
 

--- a/.github/workflows/ci-cd_release.yml
+++ b/.github/workflows/ci-cd_release.yml
@@ -39,7 +39,7 @@ jobs:
       # Build the Docker images
       - name: Build Docker image
         run: |
-          docker compose build --parallel
+          docker compose -f docker-compose.deploy.yaml build --parallel
           docker tag clio-airflow-webserver:latest lhernandez0/clio-airflow-common:latest
           docker tag clio-clio_webserver:latest lhernandez0/clio-webserver:latest
 

--- a/docker-compose.deploy.yaml
+++ b/docker-compose.deploy.yaml
@@ -327,6 +327,9 @@ services:
     restart: always
 
   clio_webserver:
+    build:
+      context: ./webserver
+      dockerfile: Dockerfile.deploy
     image: lhernandez0/clio-webserver:latest
     platform: linux/arm64
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,33 @@
 # under the License.
 #
 
+# Basic Airflow cluster configuration for CeleryExecutor with Redis and PostgreSQL.
+#
+# WARNING: This configuration is for local development. Do not use it in a production deployment.
+#
+# This configuration supports basic configuration using environment variables or an .env file
+# The following variables are supported:
+#
+# AIRFLOW_IMAGE_NAME           - Docker image name used to run Airflow.
+#                                Default: apache/airflow:2.10.0
+# AIRFLOW_UID                  - User ID in Airflow containers
+#                                Default: 50000
+# AIRFLOW_PROJ_DIR             - Base path to which all the files will be volumed.
+#                                Default: .
+# Those configurations are useful mostly in case of standalone testing/running Airflow in test/try-out mode
+#
+# _AIRFLOW_WWW_USER_USERNAME   - Username for the administrator account (if requested).
+#                                Default: airflow
+# _AIRFLOW_WWW_USER_PASSWORD   - Password for the administrator account (if requested).
+#                                Default: airflow
+# _PIP_ADDITIONAL_REQUIREMENTS - Additional PIP requirements to add when starting all containers.
+#                                Use this option ONLY for quick checks. Installing requirements at container
+#                                startup is done EVERY TIME the service is started.
+#                                A better way is to build a custom image or extend the official image
+#                                as described in https://airflow.apache.org/docs/docker-stack/build.html.
+#                                Default: ''
+#
+# Feel free to modify this file to suit your needs.
 ---
 x-airflow-common:
   &airflow-common

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,33 +16,6 @@
 # under the License.
 #
 
-# Basic Airflow cluster configuration for CeleryExecutor with Redis and PostgreSQL.
-#
-# WARNING: This configuration is for local development. Do not use it in a production deployment.
-#
-# This configuration supports basic configuration using environment variables or an .env file
-# The following variables are supported:
-#
-# AIRFLOW_IMAGE_NAME           - Docker image name used to run Airflow.
-#                                Default: apache/airflow:2.10.0
-# AIRFLOW_UID                  - User ID in Airflow containers
-#                                Default: 50000
-# AIRFLOW_PROJ_DIR             - Base path to which all the files will be volumed.
-#                                Default: .
-# Those configurations are useful mostly in case of standalone testing/running Airflow in test/try-out mode
-#
-# _AIRFLOW_WWW_USER_USERNAME   - Username for the administrator account (if requested).
-#                                Default: airflow
-# _AIRFLOW_WWW_USER_PASSWORD   - Password for the administrator account (if requested).
-#                                Default: airflow
-# _PIP_ADDITIONAL_REQUIREMENTS - Additional PIP requirements to add when starting all containers.
-#                                Use this option ONLY for quick checks. Installing requirements at container
-#                                startup is done EVERY TIME the service is started.
-#                                A better way is to build a custom image or extend the official image
-#                                as described in https://airflow.apache.org/docs/docker-stack/build.html.
-#                                Default: ''
-#
-# Feel free to modify this file to suit your needs.
 ---
 x-airflow-common:
   &airflow-common
@@ -51,7 +24,7 @@ x-airflow-common:
   # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
   # image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.10.0}
   build: .
-  platform: linux/arm64
+  platform: linux/amd64
   environment:
     &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor

--- a/webserver/Dockerfile.deploy
+++ b/webserver/Dockerfile.deploy
@@ -1,10 +1,22 @@
+# ARGs for architecture and platform
+ARG TARGETARCH=arm64
+ARG TARGETPLATFORM=linux/arm64
+ARG CHIPSET_ARCH=aarch64-linux-gnu
+
 # ARGs for Python builder and Distroless base images
 ARG PYTHON_BUILDER_IMAGE=python:3.11-slim
 ARG GOOGLE_DISTROLESS_BASE_IMAGE=gcr.io/distroless/base-debian12
-ARG CHIPSET_ARCH=x86_64-linux-gnu
+ARG CHIPSET_ARCH=aarch64-linux-gnu
 
 # First stage: Build the Python app in a slim Python image
 FROM ${PYTHON_BUILDER_IMAGE} AS python-base
+
+# Install system dependencies
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install gcc g++ -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
@@ -32,7 +44,7 @@ COPY . /app/webserver
 FROM ${GOOGLE_DISTROLESS_BASE_IMAGE}
 
 # ARG for architecture
-ARG CHIPSET_ARCH=x86_64-linux-gnu
+ARG CHIPSET_ARCH=aarch64-linux-gnu
 
 # Copy Python and installed packages from the python-base image
 COPY --from=python-base /usr/local/lib/ /usr/local/lib/
@@ -40,9 +52,9 @@ COPY --from=python-base /usr/local/bin/ /usr/local/bin/
 
 # Copy necessary runtime libraries and binaries
 COPY --from=python-base \
-    /lib/${CHIPSET_ARCH}/libz.so.1 \
-    /lib/${CHIPSET_ARCH}/libexpat* \
-    /lib/${CHIPSET_ARCH}/
+    /usr/lib/${CHIPSET_ARCH}/libz.so.1 \
+    /usr/lib/${CHIPSET_ARCH}/libexpat* \
+    /usr/lib/${CHIPSET_ARCH}/
 
 COPY --from=python-base \
     /usr/lib/${CHIPSET_ARCH}/libffi* \


### PR DESCRIPTION
### This PR will:
- Revert local development to x64/x86 Ubuntu based docker images
- Split the dockerfiles used for local development with the one used in dev/release and prod 